### PR TITLE
POC: introducing rpl_semi_sync_master_ack_server_id

### DIFF
--- a/plugin/semisync/semisync_master.cc
+++ b/plugin/semisync/semisync_master.cc
@@ -53,6 +53,7 @@ unsigned long long rpl_semi_sync_master_net_wait_time = 0;
 unsigned long long rpl_semi_sync_master_trx_wait_time = 0;
 char rpl_semi_sync_master_wait_no_slave = 1;
 unsigned int rpl_semi_sync_master_wait_for_slave_count= 1;
+unsigned long long rpl_semi_sync_master_ack_server_id     = 0;
 
 
 static int getWaitTime(const struct timespec& start_ts);

--- a/plugin/semisync/semisync_master.h
+++ b/plugin/semisync/semisync_master.h
@@ -891,6 +891,7 @@ extern unsigned long long rpl_semi_sync_master_net_wait_num;
 extern unsigned long long rpl_semi_sync_master_trx_wait_num;
 extern unsigned long long rpl_semi_sync_master_net_wait_time;
 extern unsigned long long rpl_semi_sync_master_trx_wait_time;
+extern unsigned long long rpl_semi_sync_master_ack_server_id;
 
 /*
   This indicates whether we should keep waiting if no semi-sync slave


### PR DESCRIPTION
POC for better semi-sync consistency enforcement. This PR introduces a new semi-sync variables, `rpl_semi_sync_master_ack_server_id`, default `0`.

When set to non-zero on a semi-sync master, the semi-sync mechanism will only accept acks from the (single) replica that has this value as `server_id`.

Thus, we can instruct a semi-sync master to only accept acks from a specific replica. Multiple other replicas may be configured to be semi-sync, but the master will treat them as asynchronous.

Context to follow. 